### PR TITLE
Added typed errors with `HttpErrors` and `@fastify/ansible`.

### DIFF
--- a/.changeset/plenty-tables-check.md
+++ b/.changeset/plenty-tables-check.md
@@ -1,0 +1,8 @@
+---
+'@kitajs/generator': patch
+'@kitajs/runtime': patch
+'@kitajs/common': patch
+'@kitajs/parser': patch
+---
+
+Added typed errors with HttpErrors and @fastify/ansible.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,6 @@ name: CI Flow
 
 on:
   push:
-    paths:
-      - '**.js'
-      - '**.ts'
-      - '**.json'
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/packages/common/src/errors/validator.ts
+++ b/packages/common/src/errors/validator.ts
@@ -144,8 +144,18 @@ export class InvalidHtmlRoute extends KitaError {
 export class UnknownHttpError extends KitaError {
   constructor(node: ts.Node) {
     super({
-      code: 409,
+      code: 410,
       messageText: `Could not resolve a http status code for this error, are you using a method exposed by @fastify/sensible?`,
+      node
+    });
+  }
+}
+
+export class UnknownHttpJsdocError extends KitaError {
+  constructor(node: ts.Node) {
+    super({
+      code: 411,
+      messageText: `Could not resolve a http status code for this error, please only use @throws <number>`,
       node
     });
   }

--- a/packages/common/src/errors/validator.ts
+++ b/packages/common/src/errors/validator.ts
@@ -140,3 +140,13 @@ export class InvalidHtmlRoute extends KitaError {
     });
   }
 }
+
+export class UnknownHttpError extends KitaError {
+  constructor(node: ts.Node) {
+    super({
+      code: 409,
+      messageText: `Could not resolve a http status code for this error, are you using a method exposed by @fastify/sensible?`,
+      node
+    });
+  }
+}

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -21,6 +21,7 @@
     "typescript": "~5.1.6"
   },
   "devDependencies": {
+    "@fastify/sensible": "^5.3.0",
     "@kitajs/parser": "workspace:^",
     "@kitajs/runtime": "workspace:^",
     "@types/node": "^20.8.4",

--- a/packages/generator/src/templates/route.ts
+++ b/packages/generator/src/templates/route.ts
@@ -36,9 +36,7 @@ export ${needsAsync(r.parameters)} function ${
     r.customReturn ||
     /* ts */ `
     
-    return reply.send(${r.controllerName}.${r.controllerMethod}.call(null, ${r.parameters
-      .map((p) => p.value)
-      .join(', ')}));
+    return ${r.controllerName}.${r.controllerMethod}.call(null, ${r.parameters.map((p) => p.value).join(', ')});
     
     `.trim()
   }

--- a/packages/generator/test/http-errors/index.test.ts
+++ b/packages/generator/test/http-errors/index.test.ts
@@ -1,0 +1,43 @@
+import fastifySensible from '@fastify/sensible';
+import assert from 'node:assert';
+import test, { describe } from 'node:test';
+import { createApp, generateRuntime } from '../runner';
+
+//@ts-ignore - first test may not have been run yet
+import type Runtime from './runtime';
+
+describe('Http Errors', async () => {
+  const rt = await generateRuntime<typeof Runtime>(__dirname);
+
+  test('expects getIndex was generated', () => {
+    assert.ok(rt);
+    assert.ok(rt.getIndex);
+    assert.ok(rt.getIndexHandler);
+  });
+
+  test('getIndex throws correctly', async () => {
+    const app = createApp(rt);
+
+    //@ts-expect-error - https://github.com/fastify/fastify-sensible/pull/147
+    app.register(fastifySensible, {
+      sharedSchemaId: 'HttpError'
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/' });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body, 'Success!');
+
+    const res1 = await app.inject({ method: 'GET', url: '/', query: { num: '1' } });
+
+    assert.equal(res1.statusCode, 400);
+    assert.deepStrictEqual(res1.json(), { statusCode: 400, error: 'Bad Request', message: 'Error 1!' });
+
+    const res2 = await app.inject({ method: 'GET', url: '/', query: { num: '2' } });
+
+    assert.equal(res2.statusCode, 500);
+    assert.deepStrictEqual(res2.json(), { statusCode: 500, error: 'Internal Server Error', message: 'Error 2!' });
+
+    await app.close();
+  });
+});

--- a/packages/generator/test/http-errors/routes/index.ts
+++ b/packages/generator/test/http-errors/routes/index.ts
@@ -1,0 +1,12 @@
+import type { HttpErrors, Query } from '@kitajs/runtime';
+
+export function get(errors: HttpErrors, num?: Query<number>) {
+  switch (num) {
+    case 1:
+      throw errors.badRequest('Error 1!');
+    case 2:
+      throw errors.internalServerError('Error 2!');
+    default:
+      return 'Success!';
+  }
+}

--- a/packages/parser/src/parameter-parsers/errors.ts
+++ b/packages/parser/src/parameter-parsers/errors.ts
@@ -1,0 +1,89 @@
+import {
+  InvalidParameterUsageError,
+  Parameter,
+  ParameterParser,
+  Route,
+  UnknownHttpError,
+  kFastifyParam
+} from '@kitajs/common';
+import http from 'node:http';
+import ts from 'typescript';
+import { mergeSchema } from '../schema/helpers';
+import { getTypeName, getTypeNodeName } from '../util/nodes';
+
+// A map of @fastify/sensible error names to their codes
+const messageStatusMap = {} as Record<string, string>;
+
+for (const key in http.STATUS_CODES) {
+  messageStatusMap[normalize(key, http.STATUS_CODES[key]!)] = key;
+}
+
+/**
+ * Normalize function used by fastify sensible.
+ *
+ * @link https://github.com/fastify/fastify-sensible/blob/a2f544d665d8d68c7683d94ee34fd08d9ecf3301/lib/httpErrors.js#L11C10-L11C20
+ */
+function normalize(code: string, msg: string) {
+  if (code === '414') return 'uriTooLong';
+  if (code === '505') return 'httpVersionNotSupported';
+  msg = msg.split(' ').join('').replace(/'/g, '');
+  msg = msg[0]!.toLowerCase() + msg.slice(1);
+  return msg;
+}
+
+export class ErrorsParameterParser implements ParameterParser {
+  supports(param: ts.ParameterDeclaration) {
+    return getTypeNodeName(param) === 'HttpErrors';
+  }
+
+  parse(param: ts.ParameterDeclaration, route: Route, fn: ts.FunctionDeclaration): Parameter {
+    // To find throw declarations
+    const paramValue = getTypeName(param);
+
+    if (!fn.body) {
+      throw new InvalidParameterUsageError('This function has no body', fn.name || fn);
+    }
+
+    ts.forEachChild(fn.body, function loopSourceNodes(node) {
+      if (
+        // Checks first if the node is a throw statement
+        ts.isThrowStatement(node) &&
+        // is a method call, like `throw [errors.notFound()]`
+        ts.isCallExpression(node.expression) &&
+        // is a property access expression, like `throw [errors.notFound]()`
+        ts.isPropertyAccessExpression(node.expression.expression) &&
+        // is a property access expression, like `throw [errors].notFound()`
+        ts.isIdentifier(node.expression.expression.expression) &&
+        // is the same as the parameter name
+        node.expression.expression.expression.escapedText === paramValue
+      ) {
+        // The method name, like `throw errors.[notFound]()`
+        const method = node.expression.expression.name.escapedText;
+        const status = messageStatusMap[method as string];
+
+        if (!status) {
+          throw new UnknownHttpError(node.expression.expression.name);
+        }
+
+        // Adds the route schema
+        mergeSchema(route, {
+          response: {
+            [status]: {
+              // This type will be registered by `sharedSchemaId` option
+              // from @fastify/sensible
+              $ref: 'HttpError'
+            }
+          }
+        });
+
+        return;
+      }
+
+      ts.forEachChild(node, loopSourceNodes);
+    });
+
+    return {
+      value: `${kFastifyParam}.httpErrors`
+    };
+  }
+}

--- a/packages/parser/src/parameter-parsers/index.ts
+++ b/packages/parser/src/parameter-parsers/index.ts
@@ -5,6 +5,7 @@ import { BodyPropParameterParser } from './body-prop';
 import { ChainParameterParser } from './chain';
 import { CookieParameterParser } from './cookie';
 import { ProviderParameterParser } from './custom';
+import { ErrorsParameterParser } from './errors';
 import { FastifyParameterParser } from './fastify';
 import { HeaderParameterParser } from './header';
 import { PathParameterParser } from './path';
@@ -33,7 +34,8 @@ export function buildParameterParser(
     .add(new HeaderParameterParser(config))
     .add(new CookieParameterParser())
     .add(new ThisParameterParser())
-    .add(new SuspenseIdParameterParser());
+    .add(new SuspenseIdParameterParser())
+    .add(new ErrorsParameterParser());
 
   return chain;
 }

--- a/packages/parser/test/errors/index.test.ts
+++ b/packages/parser/test/errors/index.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import test, { describe } from 'node:test';
+import { parseRoutes } from '../runner';
+
+describe('Http errors', async () => {
+  const kita = await parseRoutes(__dirname);
+
+  test('expects 1 routes were generated', () => {
+    assert.equal(kita.getProviderCount(), 0);
+    assert.equal(kita.getRouteCount(), 1);
+  });
+
+  test('assigns all possible errors', () => {
+    const route = kita.getRoute('getIndex');
+
+    assert.deepStrictEqual(route, {
+      kind: 'rest',
+      url: '/',
+      controllerMethod: 'get',
+      method: 'GET',
+      controllerName: 'IndexController',
+      controllerPath: './routes/index.ts',
+      parameters: [{ value: 'req.server.httpErrors' }],
+      schema: {
+        operationId: 'getIndex',
+        response: {
+          '409': { $ref: 'HttpError' },
+          '424': { $ref: 'HttpError' },
+          '502': { $ref: 'HttpError' },
+          '503': { $ref: 'HttpError' },
+          '2xx': { $ref: 'getIndexResponse' }
+        }
+      }
+    });
+  });
+});

--- a/packages/parser/test/errors/index.test.ts
+++ b/packages/parser/test/errors/index.test.ts
@@ -5,9 +5,9 @@ import { parseRoutes } from '../runner';
 describe('Http errors', async () => {
   const kita = await parseRoutes(__dirname);
 
-  test('expects 1 routes were generated', () => {
+  test('expects 2 routes were generated', () => {
     assert.equal(kita.getProviderCount(), 0);
-    assert.equal(kita.getRouteCount(), 1);
+    assert.equal(kita.getRouteCount(), 2);
   });
 
   test('assigns all possible errors', () => {
@@ -29,6 +29,29 @@ describe('Http errors', async () => {
           '502': { $ref: 'HttpError' },
           '503': { $ref: 'HttpError' },
           '2xx': { $ref: 'getIndexResponse' }
+        }
+      }
+    });
+  });
+
+  test('@throws jsdoc also works', () => {
+    const route = kita.getRoute('postIndex');
+
+    assert.deepStrictEqual(route, {
+      kind: 'rest',
+      url: '/',
+      controllerMethod: 'post',
+      method: 'POST',
+      controllerName: 'IndexController',
+      controllerPath: './routes/index.ts',
+      parameters: [],
+      schema: {
+        operationId: 'postIndex',
+        response: {
+          '403': { $ref: 'HttpError' },
+          '404': { $ref: 'HttpError' },
+          '405': { $ref: 'HttpError' },
+          '2xx': { $ref: 'postIndexResponse' }
         }
       }
     });

--- a/packages/parser/test/errors/index.test.ts
+++ b/packages/parser/test/errors/index.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import test, { describe } from 'node:test';
+import { cwdRelative } from '../../src';
 import { parseRoutes } from '../runner';
 
 describe('Http errors', async () => {
@@ -19,7 +20,7 @@ describe('Http errors', async () => {
       controllerMethod: 'get',
       method: 'GET',
       controllerName: 'IndexController',
-      controllerPath: './routes/index.ts',
+      controllerPath: cwdRelative('routes/index.ts'),
       parameters: [{ value: 'req.server.httpErrors' }],
       schema: {
         operationId: 'getIndex',
@@ -43,7 +44,7 @@ describe('Http errors', async () => {
       controllerMethod: 'post',
       method: 'POST',
       controllerName: 'IndexController',
-      controllerPath: './routes/index.ts',
+      controllerPath: cwdRelative('routes/index.ts'),
       parameters: [],
       schema: {
         operationId: 'postIndex',

--- a/packages/parser/test/errors/routes/index.ts
+++ b/packages/parser/test/errors/routes/index.ts
@@ -1,0 +1,87 @@
+import { HttpErrors } from '@kitajs/runtime';
+
+const maybe = false as boolean;
+const array = [1, 2, 3];
+
+export async function get(MYerRORnAMe: HttpErrors) {
+  if (maybe) {
+    // 503
+    throw MYerRORnAMe.serviceUnavailable();
+  }
+
+  array.filter((item) => {
+    if (item > 4) {
+      // 502
+      throw MYerRORnAMe.badGateway('Error!');
+    }
+  });
+
+  //@ts-ignore - should not be added as its a different variable name
+  const errors = { gone() {} };
+  if (maybe) throw errors.gone();
+
+  // Should not be added as its not a function call
+  if (maybe) {
+    throw {
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'Error 2!'
+    };
+  }
+
+  //@ts-ignore
+  function a() {
+    //@ts-ignore
+    function a() {
+      //@ts-ignore
+      function a() {
+        //@ts-ignore
+        function a() {
+          //@ts-ignore
+          function a() {
+            //@ts-ignore
+            function a() {
+              //@ts-ignore
+              function a() {
+                //@ts-ignore
+                function a() {
+                  //@ts-ignore
+                  function a() {
+                    //@ts-ignore
+                    function a() {}
+                  }
+                }
+              }
+            }
+          }
+          //@ts-ignore
+          function a() {
+            //@ts-ignore
+            function a() {
+              //@ts-ignore
+              function a() {
+                //@ts-ignore
+                function a() {
+                  //@ts-ignore
+                  function a() {
+                    //@ts-ignore
+                    function a() {
+                      // 424
+                      throw MYerRORnAMe.failedDependency('Error!');
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { hello: 'world' };
+
+  // 409
+  //@ts-ignore - never executes
+  throw MYerRORnAMe.conflict('Error!');
+}

--- a/packages/parser/test/errors/routes/index.ts
+++ b/packages/parser/test/errors/routes/index.ts
@@ -85,3 +85,12 @@ export async function get(MYerRORnAMe: HttpErrors) {
   //@ts-ignore - never executes
   throw MYerRORnAMe.conflict('Error!');
 }
+
+/**
+ * @throws 403
+ * @throws 404
+ * @throws 405
+ */
+export async function post() {
+  return { hello: 'world' };
+}

--- a/packages/parser/test/paths/index.test.ts
+++ b/packages/parser/test/paths/index.test.ts
@@ -3,7 +3,7 @@ import test, { describe } from 'node:test';
 import { cwdRelative } from '../../src';
 import { parseRoutes } from '../runner';
 
-describe('Cookies', async () => {
+describe('Paths', async () => {
   const kita = await parseRoutes(__dirname);
 
   test('expects 2 routes were generated', () => {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -24,6 +24,7 @@
     "type-fest": "^4.4.0"
   },
   "peerDependencies": {
+    "@fastify/sensible": ">=5.3",
     "fastify": ">=4.23"
   }
 }

--- a/packages/runtime/types/errors.d.ts
+++ b/packages/runtime/types/errors.d.ts
@@ -1,0 +1,44 @@
+import type { HttpErrors as _HttpErrors } from '@fastify/sensible/lib/httpError';
+
+/**
+ * Allows you to throw HTTP errors. These errors are automatically added to your route response schema.
+ *
+ * Rules:
+ *
+ * - You MUST register `fastify-sensible` plugin before using this type.
+ * - Only errors thrown with `throw` keyword are added.
+ * - Kitajs _only_ reads this function body, errors thrown elsewhere are not added and you should try/catch these calls
+ *   inside your route handler.
+ *
+ * ```ts
+ * import { HttpErrors } from '@kitajs/runtime';
+ *
+ * export function get(errors: HttpErrors) {
+ *   throw errors.notFound();
+ * }
+ *
+ * export function get(errors: HttpErrors) {
+ *   try {
+ *     return anotherCallThatThrows();
+ *   } catch (error) {
+ *     throw errors.internalServerError(error);
+ *   }
+ * }
+ * ```
+ *
+ * ## How to register:
+ *
+ * ```ts
+ * import fastifySensible from '@fastify/sensible';
+ *
+ * // Needs `HttpError` schema id to be set:
+ * app.register(fastifySensible, {
+ *   sharedSchemaId: 'HttpError'
+ * });
+ * ```
+ *
+ * TODO: Remove this type as soon https://github.com/fastify/fastify-sensible/pull/147 is merged.
+ *
+ * @see https://github.com/fastify/fastify-sensible
+ */
+export type HttpErrors = _HttpErrors;

--- a/packages/runtime/types/index.d.ts
+++ b/packages/runtime/types/index.d.ts
@@ -1,5 +1,6 @@
 export * from './body';
 export * from './cookie';
+export * from './errors';
 export * from './header';
 export * from './path';
 export * from './query';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
         specifier: ~5.1.6
         version: 5.1.6
     devDependencies:
+      '@fastify/sensible':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@kitajs/parser':
         specifier: workspace:^
         version: link:../parser
@@ -180,6 +183,9 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@fastify/sensible':
+        specifier: '>=5.3'
+        version: 5.3.0
       '@kitajs/common':
         specifier: workspace:^
         version: link:../common
@@ -723,6 +729,17 @@ packages:
     dependencies:
       fast-json-stringify: 5.7.0
 
+  /@fastify/sensible@5.3.0:
+    resolution: {integrity: sha512-/7n8kMO6G7up05MOohZ7OX3u2pUGdfOU8ai2XzY3TNSguVYUcQfyu+A0On41ijxSKo9Z9US5OMfEy+KITF4RQQ==}
+    dependencies:
+      '@lukeed/ms': 2.0.1
+      fast-deep-equal: 3.1.3
+      fastify-plugin: 4.5.1
+      forwarded: 0.2.0
+      http-errors: 2.0.0
+      type-is: 1.6.18
+      vary: 1.1.2
+
   /@gar/promisify@1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
@@ -811,6 +828,10 @@ packages:
       typescript: 5.1.6
       yargs: 17.7.2
     dev: true
+
+  /@lukeed/ms@2.0.1:
+    resolution: {integrity: sha512-Xs/4RZltsAL7pkvaNStUQt7netTkyxrS0K+RILcVr3TRMS/ToOg4I6uNfhB9SlGsnWBym4U+EaXq0f0cEMNkHA==}
+    engines: {node: '>=8'}
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2664,6 +2685,10 @@ packages:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
     dev: true
 
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   /deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
     dev: true
@@ -3639,6 +3664,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
   /http-proxy-agent@4.0.1:
     resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
     engines: {node: '>= 6'}
@@ -4427,6 +4462,10 @@ packages:
       '@types/mdast': 3.0.10
     dev: true
 
+  /media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   /mem-fs-editor@9.7.0(mem-fs@2.3.0):
     resolution: {integrity: sha512-ReB3YD24GNykmu4WeUL/FDIQtkoyGB6zfJv60yfCo3QjKeimNcTqv2FT83bP0ccs6uu+sm5zyoBlspAzigmsdg==}
     engines: {node: '>=12.10.0'}
@@ -4666,6 +4705,16 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
+
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -6075,6 +6124,9 @@ packages:
   /set-cookie-parser@2.5.1:
     resolution: {integrity: sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==}
 
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
     engines: {node: '>=0.10.0'}
@@ -6315,6 +6367,10 @@ packages:
       minipass: 3.3.6
     dev: true
 
+  /statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
   /stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
     dependencies:
@@ -6530,6 +6586,10 @@ packages:
     resolution: {integrity: sha512-3oDzcogWGHZdkwrHyvJVpPjA7oNzY6ENOV3PsWJY9XYPZ6INo94Yd47s5may1U+nleBPwDhrRiTPMIvKaa3MQg==}
     engines: {node: '>=12'}
 
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
@@ -6690,6 +6750,13 @@ packages:
   /type-fest@4.4.0:
     resolution: {integrity: sha512-HT3RRs7sTfY22KuPQJkD/XjbTbxgP2Je5HPt6H6JEGvcjHd5Lqru75EbrP3tb4FYjNJ+DjLp+MNQTFQU0mhXNw==}
     engines: {node: '>=16'}
+
+  /type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
 
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
@@ -6861,6 +6928,10 @@ packages:
     dependencies:
       builtins: 5.0.1
     dev: true
+
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   /vinyl-file@3.0.0:
     resolution: {integrity: sha512-BoJDj+ca3D9xOuPEM6RWVtWQtvEPQiQYn82LvdxhLWplfQsBzBqtgK0yhCP0s1BNTi6dH9BO+dzybvyQIacifg==}


### PR DESCRIPTION
Add support for inferring bad paths from `HttpErrors`. It analyses every AST node from the function body and tries to search for `throw errors.<method>`, jsdoc `@throws <number>` syntax is also allowed to register errors we could not find.

```ts
/**
 * @throws 500
 */
export function get(errors: HttpErrors) {
  if (badInput) {
    throw errors.badRequest('Bad Input!');
  }

  return { hello: 'World!' };
}
```

generates this route schema:

```js
{
  operationId: 'getIndex',
  response: {
    '400': { $ref: 'HttpError' },
    '500': { $ref: 'HttpError' },
    '2xx': { $ref: 'getIndexResponse' }
  }
}
```

Ideally, this should only be merged after https://github.com/fastify/fastify-sensible/pull/147.