### PR TITLE
Inlined literal object types instead of phantom references

### DIFF
--- a/.changeset/violet-cups-help.md
+++ b/.changeset/violet-cups-help.md
@@ -1,0 +1,6 @@
+---
+"@kitajs/common": patch
+"@kitajs/parser": patch
+---
+
+Inlined literal object types instead of phantom references

--- a/packages/common/src/ast/schema.ts
+++ b/packages/common/src/ast/schema.ts
@@ -13,8 +13,6 @@ export interface RouteSchema extends Partial<Record<keyof FastifySchema, Definit
    */
   operationId: string;
 
-  /**
-   * Any possible other key is also allowed
-   */
+  /** Any possible other key is also allowed */
   [key: string]: unknown;
 }

--- a/packages/common/src/config/model.ts
+++ b/packages/common/src/config/model.ts
@@ -74,7 +74,7 @@ export interface KitaConfig {
   providerParserAugmentor(parser: ChainParser<ProviderParser>): void | Promise<void>;
 }
 
-export interface KitaGeneratorConfig extends Omit<JsonConfig, 'tsconfig'> {
+export interface KitaGeneratorConfig extends Omit<JsonConfig, 'tsconfig' | 'discriminatorType'> {
   /** Extra parsers to handle ts.Nodes into Schema Nodes */
   parsers: SubNodeParser[];
   /** Extra formatters to handle Schema Nodes into json schemas */

--- a/packages/parser/src/schema/builder.ts
+++ b/packages/parser/src/schema/builder.ts
@@ -16,6 +16,7 @@ import {
   PrimitiveType,
   ReferenceType,
   Schema,
+  Config as TsjConfig,
   TupleType,
   TypeFormatter,
   UndefinedType,
@@ -39,7 +40,11 @@ export class SchemaBuilder {
     program: ts.Program,
     private collector: AstCollector
   ) {
-    const generatorCfg = { ...config.generatorConfig, tsconfig: config.tsconfig };
+    const generatorCfg: TsjConfig = {
+      ...config.generatorConfig,
+      tsconfig: config.tsconfig,
+      discriminatorType: 'open-api'
+    };
 
     this.parser = createParser(program, generatorCfg, (mut) => {
       for (const parser of config.generatorConfig.parsers) {

--- a/packages/parser/src/schema/builder.ts
+++ b/packages/parser/src/schema/builder.ts
@@ -69,7 +69,7 @@ export class SchemaBuilder {
 
   /** Saves and returns a {@linkcode ts.Node}'s respective json schema. */
   consumeNodeSchema(node: ts.TypeNode, overrideName?: string): Schema {
-    const type = this.createTypeSchema(node);
+    let type = this.createTypeSchema(node);
 
     {
       // Prevents from creating multiple `{ id: '...', type: 'string' }`-like definitions
@@ -85,6 +85,12 @@ export class SchemaBuilder {
 
     // Includes this node into our recursive definition
     this.appendChildDefinitions(type);
+
+    // @ts-expect-error - unnamed references usually means literal types
+    // inside other definitions, so we just unwrap them.
+    if (type instanceof DefinitionType && !type.name) {
+      type = type.getType();
+    }
 
     // Returns reference to this node
     return this.formatDefinition(type);
@@ -218,6 +224,11 @@ export class SchemaBuilder {
 
       // Add child definition
       if (!(name in this.definitions)) {
+        // @ts-expect-error - unnamed child should be kept inside the original definition
+        if (!child.name) {
+          continue;
+        }
+
         this.definitions[name] = this.formatter.getDefinition(child.getType());
 
         // Call schema callback if present

--- a/packages/parser/src/util/string.ts
+++ b/packages/parser/src/util/string.ts
@@ -47,3 +47,8 @@ export function findUrlAndControllerName(filepath: string, config: KitaConfig) {
 export function capitalize(this: void, str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }
+
+/** The same as {@linkcode capitalize} but does not care if the remaining string is capitalized or not. */
+export function capital(this: void, str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/packages/parser/test/body-prop/index.test.ts
+++ b/packages/parser/test/body-prop/index.test.ts
@@ -6,15 +6,11 @@ import { parseRoutes } from '../runner';
 describe('BodyProp Parameter', async () => {
   const kita = await parseRoutes(__dirname);
 
-  test('expects 1 routes was generated', () => {
+  test.only('expects 1 routes was generated', () => {
     assert.equal(kita.getProviderCount(), 0);
     assert.equal(kita.getRouteCount(), 1);
+    assert.equal(kita.getSchemaCount(), 2);
   });
-
-  //@ts-expect-error - windows builds may have a different structure
-  const schemaRef = kita.getRoute('postIndex')?.schema?.body?.properties?.a?.$ref;
-
-  assert.ok(schemaRef, 'schemaRef is not defined');
 
   test('works with multiple body prop definitions', () => {
     const route = kita.getRoute('postIndex');
@@ -40,7 +36,10 @@ describe('BodyProp Parameter', async () => {
           properties: {
             name: { type: 'string' },
             a: {
-              $ref: schemaRef
+              additionalProperties: false,
+              properties: { a: { type: 'number' } },
+              required: ['a'],
+              type: 'object'
             },
             type: { $ref: 'Type' },
             'type 2': { type: 'number' }
@@ -60,18 +59,6 @@ describe('BodyProp Parameter', async () => {
       additionalProperties: false,
       properties: { b: { type: 'number' } },
       required: ['b'],
-      type: 'object'
-    });
-  });
-
-  test('generated ref schema', () => {
-    const schema = kita.getSchema(schemaRef);
-
-    assert.deepStrictEqual(schema, {
-      $id: schemaRef,
-      additionalProperties: false,
-      properties: { a: { type: 'number' } },
-      required: ['a'],
       type: 'object'
     });
   });

--- a/packages/parser/test/body-prop/index.test.ts
+++ b/packages/parser/test/body-prop/index.test.ts
@@ -6,7 +6,7 @@ import { parseRoutes } from '../runner';
 describe('BodyProp Parameter', async () => {
   const kita = await parseRoutes(__dirname);
 
-  test.only('expects 1 routes was generated', () => {
+  test('expects 1 routes was generated', () => {
     assert.equal(kita.getProviderCount(), 0);
     assert.equal(kita.getRouteCount(), 1);
     assert.equal(kita.getSchemaCount(), 2);

--- a/packages/parser/test/html/index.test.ts
+++ b/packages/parser/test/html/index.test.ts
@@ -3,7 +3,7 @@ import test, { describe, it } from 'node:test';
 import { cwdRelative } from '../../src';
 import { parseRoutes } from '../runner';
 
-describe('Cookies', async () => {
+describe('Html routes', async () => {
   const kita = await parseRoutes(__dirname);
 
   test('expects 3 routes were generated', () => {

--- a/packages/parser/test/paths/index.test.ts
+++ b/packages/parser/test/paths/index.test.ts
@@ -3,7 +3,7 @@ import test, { describe } from 'node:test';
 import { cwdRelative } from '../../src';
 import { parseRoutes } from '../runner';
 
-describe('Cookies', async () => {
+describe('Path parameter', async () => {
   const kita = await parseRoutes(__dirname);
 
   test('expects 2 routes were generated', () => {

--- a/packages/parser/test/provider/index.test.ts
+++ b/packages/parser/test/provider/index.test.ts
@@ -26,7 +26,7 @@ describe('Providers', async () => {
         {
           value: 'param0',
           helper: 'const param0 = Resolver0();',
-          imports: [{ name: 'Resolver0', path: cwdRelative('./providers/test.ts') }],
+          imports: [{ name: 'Resolver0', path: cwdRelative('providers/test.ts') }],
           providerName: 'Resolver0',
           schemaTransformer: false
         }
@@ -47,7 +47,7 @@ describe('Providers', async () => {
       parameters: [
         {
           value: 'param0',
-          imports: [{ name: '* as Resolver0', path: cwdRelative('./providers/transformer.ts') }],
+          imports: [{ name: '* as Resolver0', path: cwdRelative('providers/transformer.ts') }],
           helper: 'const param0 = await Resolver0.default();',
           providerName: 'Resolver0',
           schemaTransformer: true
@@ -66,7 +66,7 @@ describe('Providers', async () => {
     assert.deepStrictEqual(provider, {
       async: false,
       type: 'Test',
-      providerPath: cwdRelative('./providers/test.ts'),
+      providerPath: cwdRelative('providers/test.ts'),
       parameters: [],
       schemaTransformer: false
     });
@@ -78,7 +78,7 @@ describe('Providers', async () => {
     assert.deepStrictEqual(provider, {
       async: true,
       type: 'Transformer',
-      providerPath: cwdRelative('./providers/transformer.ts'),
+      providerPath: cwdRelative('providers/transformer.ts'),
       parameters: [],
       schemaTransformer: true
     });

--- a/packages/parser/test/ref-types/index.test.ts
+++ b/packages/parser/test/ref-types/index.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import test, { describe } from 'node:test';
+import { cwdRelative } from '../../src';
 import { parseRoutes } from '../runner';
 
 describe('Schema Refs generation', async () => {
@@ -20,7 +21,7 @@ describe('Schema Refs generation', async () => {
       controllerMethod: 'post',
       method: 'POST',
       controllerName: 'IndexController',
-      controllerPath: './routes/index.ts',
+      controllerPath: cwdRelative('routes/index.ts'),
       parameters: [{ value: 'req.body' }],
       schema: {
         operationId: 'postIndex',

--- a/packages/parser/test/ref-types/index.test.ts
+++ b/packages/parser/test/ref-types/index.test.ts
@@ -1,0 +1,239 @@
+import assert from 'node:assert';
+import test, { describe } from 'node:test';
+import { parseRoutes } from '../runner';
+
+describe('Schema Refs generation', async () => {
+  const kita = await parseRoutes(__dirname);
+
+  test('expects 1 routes was generated', () => {
+    assert.equal(kita.getProviderCount(), 0);
+    assert.equal(kita.getRouteCount(), 1);
+    assert.equal(kita.getSchemaCount(), 3);
+  });
+
+  test('inline schemas were generated successfully', () => {
+    const route = kita.getRoute('postIndex');
+
+    assert.deepStrictEqual(route, {
+      kind: 'rest',
+      url: '/',
+      controllerMethod: 'post',
+      method: 'POST',
+      controllerName: 'IndexController',
+      controllerPath: './routes/index.ts',
+      parameters: [{ value: 'req.body' }],
+      schema: {
+        operationId: 'postIndex',
+        response: { '2xx': { $ref: 'postIndexResponse' } },
+        body: {
+          type: 'object',
+          properties: {
+            a: { type: 'number' },
+            b: { type: 'array', items: { $ref: 'Exported' } },
+            c: { $ref: 'Exported' },
+            d: {
+              type: 'object',
+              properties: { c: { type: 'number' } },
+              required: ['c'],
+              additionalProperties: false
+            },
+            e: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: { c: { type: 'number' } },
+                required: ['c'],
+                additionalProperties: false
+              }
+            },
+            f: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'array', items: { $ref: 'Exported' } },
+                c: { $ref: 'Exported' },
+                d: {
+                  type: 'object',
+                  properties: { c: { type: 'number' } },
+                  required: ['c'],
+                  additionalProperties: false
+                },
+                e: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: { c: { type: 'number' } },
+                    required: ['c'],
+                    additionalProperties: false
+                  }
+                }
+              },
+              required: ['a', 'b', 'c', 'd', 'e'],
+              additionalProperties: false
+            },
+            g: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'array', items: { $ref: 'Exported' } },
+                c: { $ref: 'Exported' },
+                d: {
+                  type: 'object',
+                  properties: { c: { type: 'number' } },
+                  required: ['c'],
+                  additionalProperties: false
+                },
+                e: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: { c: { type: 'number' } },
+                    required: ['c'],
+                    additionalProperties: false
+                  }
+                }
+              },
+              required: ['a', 'b', 'c', 'd', 'e'],
+              additionalProperties: false
+            },
+            h: { $ref: 'H' }
+          },
+          required: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+          additionalProperties: false
+        }
+      }
+    });
+  });
+
+  test('only Exported and H were separated into different schemas', () => {
+    const exported = kita.getSchema('Exported');
+
+    assert.deepStrictEqual(exported, {
+      $id: 'Exported',
+      type: 'object',
+      properties: { b: { type: 'number' } },
+      required: ['b'],
+      additionalProperties: false
+    });
+
+    const schema = kita.getSchema('H');
+
+    assert.deepStrictEqual(schema, {
+      $id: 'H',
+      type: 'object',
+      properties: {
+        a: { type: 'number' },
+        b: { type: 'array', items: { $ref: 'Exported' } },
+        c: { $ref: 'Exported' },
+        d: {
+          type: 'object',
+          properties: { c: { type: 'number' } },
+          required: ['c'],
+          additionalProperties: false
+        },
+        e: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { c: { type: 'number' } },
+            required: ['c'],
+            additionalProperties: false
+          }
+        }
+      },
+      required: ['a', 'b', 'c', 'd', 'e'],
+      additionalProperties: false
+    });
+  });
+
+  test('postIndexResponse was also generated', () => {
+    const response = kita.getSchema('postIndexResponse');
+
+    assert.deepStrictEqual(response, {
+      $id: 'postIndexResponse',
+      type: 'object',
+      properties: {
+        a: { type: 'number' },
+        b: { type: 'array', items: { $ref: 'Exported' } },
+        c: { $ref: 'Exported' },
+        d: {
+          type: 'object',
+          properties: { c: { type: 'number' } },
+          required: ['c'],
+          additionalProperties: false
+        },
+        e: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { c: { type: 'number' } },
+            required: ['c'],
+            additionalProperties: false
+          }
+        },
+        f: {
+          type: 'object',
+          properties: {
+            a: { type: 'number' },
+            b: { type: 'array', items: { $ref: 'Exported' } },
+            c: { $ref: 'Exported' },
+            d: {
+              type: 'object',
+              properties: { c: { type: 'number' } },
+              required: ['c'],
+              additionalProperties: false
+            },
+            e: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: { c: { type: 'number' } },
+                required: ['c'],
+                additionalProperties: false
+              }
+            }
+          },
+          required: ['a', 'b', 'c', 'd', 'e'],
+          additionalProperties: false
+        },
+        g: {
+          type: 'object',
+          properties: {
+            a: { type: 'number' },
+            b: { type: 'array', items: { $ref: 'Exported' } },
+            c: { $ref: 'Exported' },
+            d: {
+              type: 'object',
+              properties: { c: { type: 'number' } },
+              required: ['c'],
+              additionalProperties: false
+            },
+            e: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: { c: { type: 'number' } },
+                required: ['c'],
+                additionalProperties: false
+              }
+            }
+          },
+          required: ['a', 'b', 'c', 'd', 'e'],
+          additionalProperties: false
+        },
+        h: { $ref: 'H' }
+      },
+      required: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+      additionalProperties: false
+    });
+
+    // the same object as the body
+    const body = kita.getRoute('postIndex')!.schema.body;
+
+    // $id is defined only for external schemas
+    const responseWithoutId: any = { ...response };
+    delete responseWithoutId.$id;
+
+    assert.deepStrictEqual(body, responseWithoutId);
+  });
+});

--- a/packages/parser/test/ref-types/routes/index.ts
+++ b/packages/parser/test/ref-types/routes/index.ts
@@ -1,0 +1,46 @@
+import type { Body } from '@kitajs/runtime';
+
+export interface Exported {
+  b: number;
+}
+
+interface NotExported {
+  c: number;
+}
+
+interface G {
+  a: number;
+  b: Exported[];
+  c: Exported;
+  d: NotExported;
+  e: NotExported[];
+}
+
+export interface H {
+  a: number;
+  b: Exported[];
+  c: Exported;
+  d: NotExported;
+  e: NotExported[];
+}
+
+export function post(
+  body: Body<{
+    a: number;
+    b: Exported[];
+    c: Exported;
+    d: NotExported;
+    e: NotExported[];
+    f: {
+      a: number;
+      b: Exported[];
+      c: Exported;
+      d: NotExported;
+      e: NotExported[];
+    };
+    g: G;
+    h: H;
+  }>
+) {
+  return body;
+}

--- a/packages/runtime/generated/index.js
+++ b/packages/runtime/generated/index.js
@@ -1,3 +1,3 @@
 module.exports.Kita = function () {
-  throw new Error('You must run `kita build` before using @kitajs/runtime.')
-}
+  throw new Error('You must run `kita build` before using @kitajs/runtime.');
+};


### PR DESCRIPTION
This PR removes previous $refs of values like `ref-81278394` when literal object types were used inside other types. This fix should also be a good fix to `ts-json-schema-generator` itself, which generates a `DefinitionType` without name and a `type` of `ObjectType`.