### PR TITLE
Relative runtime paths to dist

### DIFF
--- a/.changeset/seven-laws-joke.md
+++ b/.changeset/seven-laws-joke.md
@@ -1,0 +1,7 @@
+---
+'@kitajs/generator': patch
+'@kitajs/ts-plugin': patch
+'@kitajs/parser': patch
+---
+
+Relative runtime paths to dist

--- a/.changeset/violet-cups-help.md
+++ b/.changeset/violet-cups-help.md
@@ -1,6 +1,6 @@
 ---
-"@kitajs/common": patch
-"@kitajs/parser": patch
+'@kitajs/common': patch
+'@kitajs/parser': patch
 ---
 
 Inlined literal object types instead of phantom references

--- a/packages/common/src/config/model.ts
+++ b/packages/common/src/config/model.ts
@@ -41,6 +41,13 @@ export interface KitaConfig {
   dist?: boolean;
 
   /**
+   * The custom path to your source root. Used when replacing the source path with the dist path.
+   *
+   * @default 'src'
+   */
+  src: string;
+
+  /**
    * The tsconfig path to use to parse the files.
    *
    * @default 'tsconfig.json'

--- a/packages/common/src/config/parser.ts
+++ b/packages/common/src/config/parser.ts
@@ -23,6 +23,7 @@ export function parseConfig(config: PartialKitaConfig = {}, root = process.cwd()
     tsconfig,
     providerFolder,
     dist: config.dist ?? true,
+    src: config.src ?? 'src',
     runtimePath: config.runtimePath,
     routeFolder,
     responses: config.responses ?? {},

--- a/packages/generator/src/util/path.ts
+++ b/packages/generator/src/util/path.ts
@@ -1,26 +1,34 @@
 import path from 'path';
 
 /** Posix: `./`, in windows: `.\\` */
-export const CURRENT_DIR = path.join('./');
+export const CURRENT_DIR = `.${path.sep}`;
+export const PREVIOUS_DIR = `..${path.sep}`;
+
+export function isRelative(p: string) {
+  if (p.startsWith(CURRENT_DIR)) {
+    return CURRENT_DIR;
+  }
+
+  if (p.startsWith(PREVIOUS_DIR)) {
+    return PREVIOUS_DIR;
+  }
+
+  return false;
+}
+
+/** Matches all \ in a string */
+const DOUBLE_BACKSLASH = /\\/g;
 
 /** Remove extension from import path */
 export function formatImport(imp: string, cwd: string) {
-  const withoutExtension = removeExt(imp);
+  imp = removeExt(imp);
 
   // Makes sure the relative import is absolute
-  if (withoutExtension.startsWith(CURRENT_DIR)) {
+  if (isRelative(imp)) {
     imp = path.resolve(cwd, imp);
-
-    // Just normalizes it
-  } else {
-    imp = path.normalize(imp);
   }
 
-  // Double escape windows paths
-  // Value: `\a`
-  // String: `\\a`
-  // String of source code: `\\\\a`
-  return imp.replace(/\\/g, '\\\\');
+  return toWin32SourcePath(imp);
 }
 
 /** Removes the extension from a path, if present. */
@@ -33,4 +41,15 @@ export function removeExt(p: string) {
   } else {
     return p;
   }
+}
+
+/**
+ * Double escape windows paths
+ *
+ * - Value: `\a`
+ * - String: `\\a`
+ * - String of source code: `\\\\a`
+ */
+export function toWin32SourcePath(p: string) {
+  return p.replace(DOUBLE_BACKSLASH, '\\\\');
 }

--- a/packages/generator/src/util/path.ts
+++ b/packages/generator/src/util/path.ts
@@ -28,7 +28,7 @@ export function formatImport(imp: string, cwd: string) {
     imp = path.resolve(cwd, imp);
   }
 
-  return toWin32SourcePath(imp);
+  return escapePath(imp);
 }
 
 /** Removes the extension from a path, if present. */
@@ -50,6 +50,6 @@ export function removeExt(p: string) {
  * - String: `\\a`
  * - String of source code: `\\\\a`
  */
-export function toWin32SourcePath(p: string) {
+export function escapePath(p: string) {
   return p.replace(DOUBLE_BACKSLASH, '\\\\');
 }

--- a/packages/generator/src/writer.ts
+++ b/packages/generator/src/writer.ts
@@ -86,6 +86,15 @@ export class KitaWriter implements SourceWriter {
           const rest = content.slice(index + line.length + 1).split('\n')[0] || '';
           const dirsDeep = rest.split(path.sep).length - 1;
 
+          console.log({
+            dirsDeep,
+            rest,
+            line: content.slice(index + line.length + 1),
+            index,
+            relative: path.relative(src, dist),
+            return: `require("${toWin32SourcePath(path.join(PREVIOUS_DIR.repeat(dirsDeep), path.relative(src, dist)))}`
+          });
+
           // dist + the amount of deep dist
           return `require("${toWin32SourcePath(path.join(PREVIOUS_DIR.repeat(dirsDeep), path.relative(src, dist)))}`;
         });

--- a/packages/generator/src/writer.ts
+++ b/packages/generator/src/writer.ts
@@ -70,7 +70,7 @@ export class KitaWriter implements SourceWriter {
     };
 
     // TODO: Add support for other entry folders than src, like `lib` or `source`
-    const src = escapePath(path.join(this.config.cwd, 'src'));
+    const src = escapePath(path.join(this.config.cwd, this.config.src));
     const dist = !!this.userDistPath && this.userDistPath;
     const escapedSep = escapePath(path.sep);
 
@@ -86,15 +86,6 @@ export class KitaWriter implements SourceWriter {
           // \n used because we do not change newLine setting inside tsconfig
           const rest = content.slice(index + line.length + escapedSep.length).split('\n')[0] || '';
           const dirsDeep = rest.split(escapedSep).length - 1;
-
-          console.log({
-            dirsDeep,
-            rest,
-            line: content.slice(index + line.length + 1),
-            index,
-            relative: path.relative(src, dist),
-            return: `require("${escapePath(path.join(PREVIOUS_DIR.repeat(dirsDeep), path.relative(src, dist)))}`
-          });
 
           // dist + the amount of deep dist
           return `require("${escapePath(path.join(PREVIOUS_DIR.repeat(dirsDeep), path.relative(src, dist)))}`;

--- a/packages/generator/src/writer.ts
+++ b/packages/generator/src/writer.ts
@@ -82,7 +82,8 @@ export class KitaWriter implements SourceWriter {
         // TODO: Add support for other entry folders than src, like `lib` or `source`
         content = content.replaceAll(`require("${src}`, (line, index) => {
           // `/path/file");\n...` -> `path/file");`
-          const rest = content.slice(index + line.length + 1).split(EOL)[0] || '';
+          // \n used because we do not change newLine setting inside tsconfig
+          const rest = content.slice(index + line.length + 1).split('\n')[0] || '';
           const dirsDeep = rest.split(path.sep).length - 1;
 
           // dist + the amount of deep dist

--- a/packages/generator/src/writer.ts
+++ b/packages/generator/src/writer.ts
@@ -71,7 +71,7 @@ export class KitaWriter implements SourceWriter {
 
     // TODO: Add support for other entry folders than src, like `lib` or `source`
     const src = toWin32SourcePath(path.join(this.config.cwd, 'src'));
-    const dist = !!this.userDistPath && toWin32SourcePath(this.userDistPath);
+    const dist = !!this.userDistPath && this.userDistPath;
 
     // To avoid overwrite source files after second `tsc` run,
     // we keep aliases inside tsconfig for dts files and use relative
@@ -86,7 +86,7 @@ export class KitaWriter implements SourceWriter {
           const dirsDeep = rest.split(path.sep).length - 1;
 
           // dist + the amount of deep dist
-          return `require("${path.join(PREVIOUS_DIR.repeat(dirsDeep), path.relative(src, dist))}`;
+          return `require("${toWin32SourcePath(path.join(PREVIOUS_DIR.repeat(dirsDeep), path.relative(src, dist)))}`;
         });
       }
 

--- a/packages/generator/test/runner.ts
+++ b/packages/generator/test/runner.ts
@@ -17,6 +17,7 @@ export async function generateRuntime<R>(cwd: string, partialCfg: PartialKitaCon
     routeFolder: 'routes',
     providerFolder: 'providers',
     runtimePath: path.resolve(cwd, 'runtime'),
+    dist: false,
     ...partialCfg
   });
 

--- a/packages/generator/test/runner.ts
+++ b/packages/generator/test/runner.ts
@@ -8,9 +8,11 @@ import { KitaFormatter } from '../src';
 
 const tsconfig = require.resolve('../tsconfig.json');
 
-export async function generateRuntime<R>(cwd: string, partialCfg: PartialKitaConfig = {}): Promise<R> {
-  const compilerOptions = readCompilerOptions(tsconfig);
-
+export async function generateRuntime<R>(
+  cwd: string,
+  partialCfg: PartialKitaConfig = {},
+  compilerOptions = readCompilerOptions(tsconfig)
+): Promise<R> {
   const config = parseConfig({
     cwd,
     tsconfig,

--- a/packages/generator/test/with-dist/index.test.ts
+++ b/packages/generator/test/with-dist/index.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert';
+import test, { describe } from 'node:test';
+import { createApp, generateRuntime } from '../runner';
+
+//@ts-ignore - first test may not have been run yet
+import path from 'node:path';
+import ts from 'typescript';
+import type Runtime from './runtime';
+
+describe('Hello World', async () => {
+  const program = ts.createProgram([require.resolve('./src/_ignore.ts'), require.resolve('./src/routes/index.ts')], {
+    outDir: path.join('./dist'),
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.CommonJS,
+    baseUrl: __dirname
+  });
+
+  program.emit();
+
+  const rt = await generateRuntime<typeof Runtime>(__dirname, {
+    cwd: __dirname,
+    dist: true,
+    routeFolder: 'src/routes',
+    providerFolder: 'src/providers',
+    tsconfig: require.resolve('./tsconfig.json')
+  });
+
+  test('expects getIndex was generated', () => {
+    assert.ok(rt);
+    assert.ok(rt.getIndex);
+    assert.ok(rt.getIndexHandler);
+  });
+
+  test('methods are bound correctly', () => {
+    assert.equal(rt.getIndex(), 'Hello World!');
+    assert.equal(rt.getIndex('Arthur'), 'Hello Arthur!');
+  });
+
+  test('getIndex options were generated', async () => {
+    const app = createApp(rt);
+
+    const res = await app.inject({ method: 'GET', url: '/' });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body, 'Hello World!');
+
+    await app.close();
+  });
+});

--- a/packages/generator/test/with-dist/index.test.ts
+++ b/packages/generator/test/with-dist/index.test.ts
@@ -7,10 +7,10 @@ import { readCompilerOptions } from '@kitajs/common';
 import ts from 'typescript';
 import type Runtime from './runtime';
 
-describe('Dist usage', async () => {
-  const tsconfig = require.resolve('./tsconfig.json');
-  const compilerOptions = readCompilerOptions(tsconfig);
+const tsconfig = require.resolve('./tsconfig.json');
+const compilerOptions = readCompilerOptions(tsconfig);
 
+describe('Dist usage', async () => {
   const program = ts.createProgram(
     [require.resolve('./src/_ignore.ts'), require.resolve('./src/routes/index.ts')],
     compilerOptions

--- a/packages/generator/test/with-dist/index.test.ts
+++ b/packages/generator/test/with-dist/index.test.ts
@@ -3,27 +3,32 @@ import test, { describe } from 'node:test';
 import { createApp, generateRuntime } from '../runner';
 
 //@ts-ignore - first test may not have been run yet
-import path from 'node:path';
+import { readCompilerOptions } from '@kitajs/common';
 import ts from 'typescript';
 import type Runtime from './runtime';
 
-describe('Hello World', async () => {
-  const program = ts.createProgram([require.resolve('./src/_ignore.ts'), require.resolve('./src/routes/index.ts')], {
-    outDir: path.join('./dist'),
-    target: ts.ScriptTarget.ES2022,
-    module: ts.ModuleKind.CommonJS,
-    baseUrl: __dirname
-  });
+describe('Dist usage', async () => {
+  const tsconfig = require.resolve('./tsconfig.json');
+  const compilerOptions = readCompilerOptions(tsconfig);
+
+  const program = ts.createProgram(
+    [require.resolve('./src/_ignore.ts'), require.resolve('./src/routes/index.ts')],
+    compilerOptions
+  );
 
   program.emit();
 
-  const rt = await generateRuntime<typeof Runtime>(__dirname, {
-    cwd: __dirname,
-    dist: true,
-    routeFolder: 'src/routes',
-    providerFolder: 'src/providers',
-    tsconfig: require.resolve('./tsconfig.json')
-  });
+  const rt = await generateRuntime<typeof Runtime>(
+    __dirname,
+    {
+      cwd: __dirname,
+      dist: true,
+      routeFolder: 'src/routes',
+      providerFolder: 'src/providers',
+      tsconfig: tsconfig
+    },
+    compilerOptions
+  );
 
   test('expects getIndex was generated', () => {
     assert.ok(rt);

--- a/packages/generator/test/with-dist/src/_ignore.ts
+++ b/packages/generator/test/with-dist/src/_ignore.ts
@@ -1,0 +1,2 @@
+// simple file to keep tsc dist format of /index.ts and /routes/<routes>
+export {};

--- a/packages/generator/test/with-dist/src/routes/index.ts
+++ b/packages/generator/test/with-dist/src/routes/index.ts
@@ -1,0 +1,5 @@
+import type { Query } from '@kitajs/runtime';
+
+export function get(name: Query = 'World') {
+  return `Hello ${name}!`;
+}

--- a/packages/generator/test/with-dist/tsconfig.json
+++ b/packages/generator/test/with-dist/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "module": "CommonJS",
-    "target": "ES2021"
+    "target": "ES2021",
+    "baseUrl": "."
   },
   "include": ["src"]
 }

--- a/packages/generator/test/with-dist/tsconfig.json
+++ b/packages/generator/test/with-dist/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "CommonJS",
+    "target": "ES2021"
+  },
+  "include": ["src"]
+}

--- a/packages/parser/src/util/codegen.ts
+++ b/packages/parser/src/util/codegen.ts
@@ -1,3 +1,5 @@
+import { EOL } from 'node:os';
+
 /** Join code lines with a semicolon. */
 export function join<I>(items: I[], mapper: (this: void, t: I) => string, filter?: (this: void, t: I) => boolean) {
   let code = '';
@@ -7,7 +9,7 @@ export function join<I>(items: I[], mapper: (this: void, t: I) => string, filter
       continue;
     }
 
-    code += mapper(item).trim() + '\n';
+    code += mapper(item).trim() + EOL;
   }
 
   return code;

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -1,5 +1,6 @@
 import { KitaConfig, KitaError, importConfig, parseConfig } from '@kitajs/common';
 import { KitaParser, walk } from '@kitajs/parser';
+import { EOL } from 'os';
 import path from 'path';
 import ts, { server } from 'typescript/lib/tsserverlibrary';
 import { appendProviderDiagnostics } from './parsers/provider';
@@ -86,7 +87,7 @@ export = function initHtmlPlugin() {
             return diagnostics;
           }
 
-          info.project.projectService.logger.msg(`[kita-plugin] Error:\n${error.stack}`, ts.server.Msg.Err);
+          info.project.projectService.logger.msg(`[kita-plugin] Error:${EOL}${error.stack}`, ts.server.Msg.Err);
         }
 
         return diagnostics;


### PR DESCRIPTION
This PR removes previous absolute paths to dist inside .js code to a relative path from the runtime to the dist code. It also fixes previous extension problems inside linux/codespaces.