### PR TITLE
Fixed runtime resolve for global installs

### DIFF
--- a/.changeset/rich-ladybugs-raise.md
+++ b/.changeset/rich-ladybugs-raise.md
@@ -1,0 +1,5 @@
+---
+'@kitajs/generator': patch
+---
+
+Fixed runtime resolve for global installs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,5 @@ jobs:
           # https://github.com/changesets/changesets/pull/674
           publish: pnpm ci:publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/generator/src/writer.ts
+++ b/packages/generator/src/writer.ts
@@ -22,7 +22,12 @@ export class KitaWriter implements SourceWriter {
     if (this.config.runtimePath) {
       this.compilerOptions.outDir = path.resolve(this.config.runtimePath);
     } else {
-      this.compilerOptions.outDir = path.dirname(require.resolve('@kitajs/runtime/generated'));
+      this.compilerOptions.outDir = path.dirname(
+        require.resolve('@kitajs/runtime/generated', {
+          // Allows global installations to work
+          paths: [this.config.cwd]
+        })
+      );
     }
 
     // TODO: Figure out esm


### PR DESCRIPTION
Kita CLI did not work when installing globally because of a `require.resolve` call. It now resolves to the caller cwd instead of the real filepath.