### PR TITLE
Project Naming and Path Resolution Enhancements

### DIFF
--- a/.changeset/early-turkeys-deliver.md
+++ b/.changeset/early-turkeys-deliver.md
@@ -1,0 +1,5 @@
+---
+"@kitajs/cli": patch
+---
+
+Fixed project name detection and path resolution on Windows

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -58,7 +58,7 @@ export default class Create extends Command {
           type: 'input',
           name: 'projectName',
           message: 'What is the name of your project?',
-          default: flags.name || process.cwd().split('/').pop()!,
+          default: flags.name || path.basename(process.cwd()),
           when: !flags.yes,
           askAnswered: true
         },
@@ -82,7 +82,7 @@ export default class Create extends Command {
         }
       ],
       {
-        projectName: process.cwd().split('/').pop()!,
+        projectName: path.basename(process.cwd()),
         directory: path.resolve(flags.dir || ''),
         template: 'kita'
       }
@@ -120,7 +120,7 @@ export default class Create extends Command {
     // replaces package.json and reame @kitajs/template with the project name
     const packageJsonPath = path.resolve(answers.directory, 'package.json');
     const packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf-8'));
-    packageJson.name = answers.projectName;
+    packageJson.name = answers.projectName === '.' ? path.basename(process.cwd()) : answers.projectName;
     await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
     const readmePath = path.resolve(answers.directory, 'README.md');


### PR DESCRIPTION
Implemented two key updates to improve the user experience with the Kita CLI:

1. **Enhanced Project Naming**: Now allows `.` as input to automatically use the current directory's name as the project name. This makes project setup quicker and aligns with common CLI conventions.

2. **Fixed Cross-Platform Path Issues**: Switched to using `path.basename(process.cwd())` for determining the project's default name, ensuring consistent behavior across all operating systems.

These changes streamline project creation and ensure compatibility across different environments.