### PR TITLE
Updated link added to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 <br />
 
 <p align="center" >
-  <a href="https://kita.js.org" target="_blank" rel="noopener noreferrer">
-    <img src="https://kita.js.org/logo.png" width="180" alt="Kita JS logo" />
+  <a href="https://kitajs.org" target="_blank" rel="noopener noreferrer">
+    <img src="https://kitajs.org/logo.svg" width="180" alt="Kita JS logo" />
   </a>
 </p>
 
 <br />
 
 <div align="center">
-  <a href="https://kita.js.org/discord"><img src="https://img.shields.io/discord/1216165027774595112?logo=discord&logoColor=white&color=%237289da" alt="Discord"></a>
+  <a href="https://kitajs.org/discord"><img src="https://img.shields.io/discord/1216165027774595112?logo=discord&logoColor=white&color=%237289da" alt="Discord"></a>
   <a title="MIT license" target="_blank" href="https://github.com/kitajs/kitajs/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/github/license/kitajs/kitajs"></a>
   <a title="Codecov" target="_blank" href="https://app.codecov.io/gh/kitajs/kitajs"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/kitajs/kitajs?token=ML0KGCU0VM"></a>
   <a title="Last Commit" target="_blank" href="https://github.com/kitajs/kitajs/commits/master"><img alt="Last commit" src="https://img.shields.io/github/last-commit/kitajs/kitajs"></a>
@@ -30,14 +30,14 @@
 <h1>🌷 KitaJS</h1>
 
 <p align="center">
-  <a href="https://kita.js.org" target="_blank">KitaJS</a> is a routing meta framework.
+  <a href="https://kitajs.org" target="_blank">KitaJS</a> is a routing meta framework.
   <br />
   <br />
 </p>
 
 <br />
 
-<h1 align=center>🎉 Kita is officially Stable! <a href="https://kita.js.org/quickstart#automatic-installation">Try it out today!</a></h1>
+<h1 align=center>🎉 Kita is officially Stable! <a href="https://kitajs.org/quickstart#automatic-installation">Try it out today!</a></h1>
 
 <br />
 


### PR DESCRIPTION
Logo link and format fixed. 

❌ https://kita.js.org
✅  https://kitajs.org

now all /routes working, like  https://kitajs.org/discord and https://kitajs.org/quickstart#automatic-installation
